### PR TITLE
Update `requires_core_version` to v0.18.124

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -33,7 +33,7 @@ description: "A custom Nuke node that creates a quicktime and uploads it to Shot
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.00"
+requires_core_version: "v0.18.124"
 requires_engine_version: "v0.2.3"
 
 # the engines that this app can operate in:


### PR DESCRIPTION
In `python/dialog.py`, `base_class` is used in `execute_hook_method` . But only tk-core v0.18.124 supports base class restriction for hook interfaces.
